### PR TITLE
Added missing primary key for schemas that have composite key

### DIFF
--- a/schema/BookBorrower.js
+++ b/schema/BookBorrower.js
@@ -26,6 +26,12 @@ cube(`BookBorrower`, {
   },
   
   dimensions: {
+    id: {
+      sql: `CONCAT(${CUBE}.user_id, ${CUBE}.library_book_id)`,
+      type: `number`,
+      primaryKey: true
+    },
+
     createdAt: {
       sql: `created_at`,
       type: `time`

--- a/schema/BookReaders.js
+++ b/schema/BookReaders.js
@@ -26,7 +26,11 @@ cube(`BookReaders`, {
   },
   
   dimensions: {
-    
+    id: {
+      sql: `CONCAT(${CUBE}.user_id, ${CUBE}.library_book_id)`,
+      type: `number`,
+      primaryKey: true
+    },
   },
   
   dataSource: `default`

--- a/schema/BookWishlist.js
+++ b/schema/BookWishlist.js
@@ -26,7 +26,11 @@ cube(`BookWishlist`, {
   },
   
   dimensions: {
-    
+    id: {
+      sql: `CONCAT(${CUBE}.user_id, ${CUBE}.library_book_id)`,
+      type: `number`,
+      primaryKey: true
+    },
   },
   
   dataSource: `default`

--- a/schema/EmployeeProjectsOld.js
+++ b/schema/EmployeeProjectsOld.js
@@ -26,6 +26,12 @@ cube(`EmployeeProjectsOld`, {
   },
   
   dimensions: {
+    id: {
+      sql: `CONCAT(${CUBE}.employee_id, ${CUBE}.project_id)`,
+      type: `number`,
+      primaryKey: true
+    },
+
     contributionType: {
       sql: `contribution_type`,
       type: `string`

--- a/schema/HrJobsRounds.js
+++ b/schema/HrJobsRounds.js
@@ -26,6 +26,11 @@ cube(`HrJobsRounds`, {
   },
   
   dimensions: {
+    id: {
+      sql: `CONCAT(${CUBE}.hr_job_id, ${CUBE}.hr_round_id)`,
+      type: `number`,
+      primaryKey: true
+    },
     
   },
   

--- a/schema/LibraryBookCategory.js
+++ b/schema/LibraryBookCategory.js
@@ -26,7 +26,11 @@ cube(`LibraryBookCategory`, {
   },
   
   dimensions: {
-    
+    id: {
+      sql: `CONCAT(${CUBE}.book_category_id, ${CUBE}.library_book_id)`,
+      type: `number`,
+      primaryKey: true
+    },
   },
   
   dataSource: `default`

--- a/schema/ModelHasPermissions.js
+++ b/schema/ModelHasPermissions.js
@@ -21,6 +21,12 @@ cube(`ModelHasPermissions`, {
   },
   
   dimensions: {
+    id: {
+      sql: `CONCAT(${CUBE}.permission_id, ${CUBE}.model_id, ${CUBE}.model_type)`,
+      type: `number`,
+      primaryKey: true
+    },
+
     modelType: {
       sql: `model_type`,
       type: `string`

--- a/schema/ModelHasRoles.js
+++ b/schema/ModelHasRoles.js
@@ -21,6 +21,12 @@ cube(`ModelHasRoles`, {
   },
   
   dimensions: {
+    id: {
+      sql: `CONCAT(${CUBE}.role_id, ${CUBE}.model_id, ${CUBE}.model_type)`,
+      type: `number`,
+      primaryKey: true
+    },
+
     modelType: {
       sql: `model_type`,
       type: `string`

--- a/schema/ProjectsOldFinanceInvoices.js
+++ b/schema/ProjectsOldFinanceInvoices.js
@@ -26,7 +26,11 @@ cube(`ProjectsOldFinanceInvoices`, {
   },
   
   dimensions: {
-    
+    id: {
+      sql: `CONCAT(${CUBE}.project_id, ${CUBE}.finance_invoice_id)`,
+      type: `number`,
+      primaryKey: true
+    },
   },
   
   dataSource: `default`

--- a/schema/RoleHasPermissions.js
+++ b/schema/RoleHasPermissions.js
@@ -26,7 +26,11 @@ cube(`RoleHasPermissions`, {
   },
   
   dimensions: {
-    
+    id: {
+      sql: `CONCAT(${CUBE}.permission_id, ${CUBE}.role_id)`,
+      type: `number`,
+      primaryKey: true
+    },
   },
   
   dataSource: `default`

--- a/schema/SalesAreaQuestions.js
+++ b/schema/SalesAreaQuestions.js
@@ -26,7 +26,11 @@ cube(`SalesAreaQuestions`, {
   },
   
   dimensions: {
-    
+    id: {
+      sql: `CONCAT(${CUBE}.sales_area_id, ${CUBE}.sales_question_id)`,
+      type: `number`,
+      primaryKey: true
+    },
   },
   
   dataSource: `default`


### PR DESCRIPTION
Closes #3 

### Summary

Added `dimensions.id` for all the cubes that have a composite primary key.

From the [docs](https://cube.dev/docs/many-to-many-relationship):

> In case when a table doesn't have a primary key you can define it manually as follows
```js
cube(`PostTopics`, {
  // ...

  dimensions: {
    id: {
      sql: `CONCAT(${CUBE}.post_id, ${CUBE}.topic_id)`,
      type: `number`,
      primaryKey: true
    },
  }
});
```